### PR TITLE
Remove Renderable Class

### DIFF
--- a/cassie-hs/cassie-hs.cabal
+++ b/cassie-hs/cassie-hs.cabal
@@ -18,6 +18,7 @@ common warnings
 
 library
     import:             warnings
+    
     exposed-modules:    Data.Cassie.Parser,
                         Data.Cassie.Parser.Internal,
                         Data.Cassie.Parser.Lang,
@@ -25,16 +26,16 @@ library
                         Data.Cassie.Internal,
                         Data.Cassie.Isolate,
                         -- Data.Cassie.Isolate.PolySolve,
-                        Data.Cassie.Structures,
-                        Data.Cassie.Structures.Internal,
+                        Data.Cassie.Structures,                       
+                        Data.Cassie.Substitute,
+                        Data.Cassie.Utils,
+                        Data.Cassie,
+
+    other-modules:      Data.Cassie.Structures.Internal,
                         Data.Cassie.Structures.Instances.Complex,
                         Data.Cassie.Structures.Instances.Real,
                         Data.Cassie.Structures.Magmas,
                         Data.Cassie.Structures.UnarySystems,
-                        Data.Cassie.Substitute,
-                        Data.Cassie.Utils,
-                        Data.Cassie,
-    -- other-modules:
     -- other-extensions:
     -- Build uses GHC 9.2.8 by default, use up to 4.21.0.0 to satisfy experimental WASM backend
     build-depends:      base        >= 4.16.4.0 && <= 4.21.0.0, 

--- a/cassie-hs/src/Data/Cassie/Isolate.hs
+++ b/cassie-hs/src/Data/Cassie/Isolate.hs
@@ -159,6 +159,10 @@ isIsolated eqn sym = case isolate sym eqn Map.empty of
 -- | Puts a snapshot of the current state of the equation being solved into the 
 --   log of steps taken in the solution. 
 logStep :: AlgebraicStructure m u n => Isolate m u n ()
-logStep = do
-    step <- render <$> get
-    tell [step]
+logStep = 
+    let 
+        show' = show . ShowAlgStruct
+    in do
+        eqn <- get
+        let step = show' (lhs eqn) ++ " = " ++  show' (rhs eqn)
+        tell [step]

--- a/cassie-hs/src/Data/Cassie/Structures.hs
+++ b/cassie-hs/src/Data/Cassie/Structures.hs
@@ -23,7 +23,7 @@ module Data.Cassie.Structures
     , RealEqn
     , RealMagma(..)
     , RealUnary(..)
-    , Renderable(..)
+    , ShowAlgStruct(..)
     , Symbol
     , UnaryMock(..)
     ) where
@@ -34,14 +34,13 @@ import safe Data.Cassie.Structures.Instances.Real
 import safe Data.Cassie.Structures.UnarySystems
 import safe Data.Cassie.Structures.Internal
 
-
 class ( MagmaMock m n
       , CancelMagma m
       , UnaryMock u n
       , CancelUnary u
-      , Renderable m
-      , Renderable u
-      , Renderable n
+      , ShowMagma m
+      , ShowUnary u
+      , Show n
       , Num n
       , Fractional n
       , Eq m
@@ -54,6 +53,6 @@ instance AlgebraicStructure RealMagma RealUnary Double
 instance ( Num n
          , Floating n
          , Fractional n
-         , Renderable n
+         , Show n
          , Eq n
          ) => AlgebraicStructure ComplexMagma ComplexUnary n

--- a/cassie-hs/src/Data/Cassie/Structures/Instances/Complex.hs
+++ b/cassie-hs/src/Data/Cassie/Structures/Instances/Complex.hs
@@ -32,8 +32,8 @@ instance CancelMagma ComplexMagma where
 
     rCancel (ComplexMagma cm) = join (+++) ComplexMagma <$> rCancel cm
 
-instance Renderable ComplexMagma where
-    render (ComplexMagma cm) = render cm
+instance ShowMagma ComplexMagma where
+    showMagma (ComplexMagma cm) = showMagma cm
 
 newtype ComplexUnary = ComplexUnary TrigUnary deriving (Show, Eq, Ord)
 
@@ -43,5 +43,5 @@ instance Floating a => UnaryMock ComplexUnary a where
 instance CancelUnary ComplexUnary where
     cancel (ComplexUnary cu) = ComplexUnary <$> cancel cu
 
-instance Renderable ComplexUnary where
-    render (ComplexUnary cu) = render cu
+instance ShowUnary ComplexUnary where
+    showUnary (ComplexUnary cu) = showUnary cu

--- a/cassie-hs/src/Data/Cassie/Structures/Instances/Real.hs
+++ b/cassie-hs/src/Data/Cassie/Structures/Instances/Real.hs
@@ -30,8 +30,8 @@ instance CancelMagma RealMagma where
 
     rCancel (RealMagma rm) = join (+++) RealMagma <$> rCancel rm
 
-instance Renderable RealMagma where
-    render (RealMagma rm) = render rm
+instance ShowMagma RealMagma where
+    showMagma (RealMagma rm) = showMagma rm
 
 newtype RealUnary = RealUnary TrigUnary deriving (Show, Eq, Ord)
 
@@ -41,5 +41,5 @@ instance UnaryMock RealUnary Double where
 instance CancelUnary RealUnary where
     cancel (RealUnary ru) = RealUnary <$> cancel ru
 
-instance Renderable RealUnary where
-    render (RealUnary ru) = render ru
+instance ShowUnary RealUnary where
+    showUnary (RealUnary ru) = showUnary ru

--- a/cassie-hs/src/Data/Cassie/Structures/Magmas.hs
+++ b/cassie-hs/src/Data/Cassie/Structures/Magmas.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Data.Cassie.Structures.Magmas 
     ( isolateLeftOperand
@@ -7,6 +8,7 @@ module Data.Cassie.Structures.Magmas
     , CancelMagma(..)
     , ExpnMagma(..)
     , MagmaMock(..)
+    , ShowMagma(..)
     ) where
 
 import safe Data.Cassie.Structures.Internal
@@ -26,6 +28,10 @@ class CancelMagma m where
     -- | Given a magma operation and a right operand, this function yields a
     --   function that performs the inverse operation on an algebraic structure.
     rCancel :: m -> Maybe (Either m m)
+
+class Show m => ShowMagma m where
+    showMagma :: Show a => m -> (a -> a -> String)
+    showMagma x = \l r -> show l ++ show x ++ show r
 
 data ExpnMagma = Expn | Logm | Root deriving (Show, Eq, Ord)
 
@@ -61,7 +67,7 @@ instance CancelMagma ExpnMagma where
             Logm -> Right Root
             Root -> Left Logm
 
-instance Renderable ExpnMagma where
-    render Expn = "^"
-    render Logm = ">("
-    render Root = ">("
+instance ShowMagma ExpnMagma where
+    showMagma Expn = \x y -> show x ++ " ^ " ++ show y
+    showMagma Logm = \x y -> "log<" ++ show x ++ ">(" ++ show y ++ ")"
+    showMagma Root = \x y -> "root<" ++ show x ++ ">(" ++ show y ++ ")"

--- a/cassie-hs/src/Data/Cassie/Structures/UnarySystems.hs
+++ b/cassie-hs/src/Data/Cassie/Structures/UnarySystems.hs
@@ -5,9 +5,8 @@ module Data.Cassie.Structures.UnarySystems
     ( TrigUnary(..)
     , CancelUnary(..)
     , UnaryMock(..)
+    , ShowUnary(..)
     ) where
-
-import Data.Cassie.Structures.Internal
 
 class UnaryMock u n where
     -- | Maps a marker representing a unary system operation to its appropriate
@@ -19,6 +18,10 @@ class UnaryMock u n where
 class CancelUnary u where
     -- | Yields the inverse operation of the one given.
     cancel :: u -> Maybe u
+
+class Show u => ShowUnary u where
+    showUnary :: Show a => u -> (a -> String)
+    showUnary x = \y -> show x ++ "(" ++ show y ++ ")"
 
 data TrigUnary = Sin | Cos | Tan | ASin | ACos | ATan deriving (Show, Eq, Ord)
 
@@ -40,10 +43,10 @@ instance CancelUnary TrigUnary where
             ACos -> Cos
             ATan -> Tan
 
-instance Renderable TrigUnary where
-    render Sin = "sin"
-    render Cos = "cos"
-    render Tan = "tan"
-    render ASin = "arcsin"
-    render ACos = "arccos"
-    render ATan = "arctan"
+instance ShowUnary TrigUnary where
+    showUnary Sin  = \x -> "sin(" ++ show x ++ ")"
+    showUnary Cos  = \x -> "cos(" ++ show x ++ ")"
+    showUnary Tan  = \x -> "tan(" ++ show x ++ ")"
+    showUnary ASin = \x -> "arcsin(" ++ show x ++ ")"
+    showUnary ACos = \x -> "arccos(" ++ show x ++ ")"
+    showUnary ATan = \x -> "arctan(" ++ show x ++ ")"


### PR DESCRIPTION
This PR removes the `Renderable` class in favor of implementing `Show` on a `newtype` wrapper for `AlgStruct m u n` (`ShowAlgStruct m u n`). The rationale for this change is as follows: 
1. `Show` already does what is needed and arguably better obeys the principle of least surprise since it is part of `Prelude`
2. Similarly, `newtype`s allow for alternative implementations of classes for the same data, better matching the needed behavior for a "pretty" version of `show` for `AlgStruct m u n`